### PR TITLE
added manifest.json and getting-started.md

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -1,0 +1,35 @@
+# Momentum Health - Getting Started
+
+## Files
+
+Every extension has the following files:
+
++ A manifest file (manifest.json)
++ One or more HTML files (unless the extension is a theme)
++ Optional: One or more JavaScript files
++ Optional: Any other files your extension needs—for example, image files
+
+## The manifest.json file
+
+**Required manifest entries**
+
+```javascript
+  "manifest_version": 2,  
+  "name": "My Extension",  
+  "version": "versionString"
+```
+
+**To replace the default Chrome Tab with the Momentum Health tab page**
+
+```javascript
+  "chrome_url_overrides": {  
+    "newtab": "index.html"  
+  }
+```
+
+## Loading the extension from your local files
++ Visit chrome://extensions in your browser (or open up the Chrome menu by clicking the icon to the far right of the Omnibox, and select _Extensions_ under the _More tools_ menu to get to the same place).
++ Ensure that the Developer mode checkbox in the top right-hand corner is checked.
++ Click _Load unpacked extension_, to pop up a file-selection dialog.
++ Navigate to the directory in which your extension files live, and select it.
++ Alternatively, you can drag and drop the directory where your extension files live onto chrome://extensions in your browser to load it.

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,9 @@
+{
+  "manifest_version": 2,
+  "name": "Momentum Health",
+  "version": "0.0.1",
+  "description": "TODO: a description of the extension goes here",
+  "chrome_url_overrides": {
+    "newtab": "index.html"
+  }
+}


### PR DESCRIPTION
This PR contains a very basic manifest.json file, to convert the current index.html page into a Chrome extension, and a .md file which explains the contents of the manifest and how to install the extension from a local folder.