### PR TITLE
Adds to API string query to filter for lnadscape imgs

### DIFF
--- a/js/background-image.js
+++ b/js/background-image.js
@@ -2,7 +2,7 @@
 
 const bg = {
   defaultBgUrl: "https://images.unsplash.com/photo-1473800447596-01729482b8eb?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&s=40eba4c15ec393c84db9c76380d26869",
-  query: "https://api.unsplash.com/photos/random?collections=1291922" + "&client_id=" + "51eeacda52a858956883fcd86384424f78d38da8fb4f8b61b65723e41223d6b1",
+  query: "https://api.unsplash.com/photos/random?collections=1291922" + "&client_id=" + "51eeacda52a858956883fcd86384424f78d38da8fb4f8b61b65723e41223d6b1" + "orientation=landscape",
   renderPhotographer: document.querySelector("#image-photographer"),
   renderLocation: document.querySelector("#image-location"),
 };


### PR DESCRIPTION
Let's try this again...

Fixes #54 by adding a query parameter filtering for landscape photos. This solution doesn't prevent photos from being cropped since 'landscape' could mean an aspect ratio nearly 1:1 and most computer screens have an aspect ratio of 16:10/16:9. But, this does help prevent extreme cropping, as was happening with 'portrait' photos.