### PR TITLE
fixes #104 Todo list will sometimes open with no list selected

### DIFF
--- a/js/todo.js
+++ b/js/todo.js
@@ -82,6 +82,7 @@
           deleteList();
           addNewList();
           addNewTask();
+          applyDefaultListSelect();
           applySelectToggle();
           renderTodoStatus();
           taskReveal();


### PR DESCRIPTION
Fixes #104 Todo list will sometimes open with no list selected
Added call to `applyDefaultListSelect()` to function calls in `getStoredTodo`.